### PR TITLE
Added tractography values/cmap

### DIFF
--- a/src/open_dive/scripts/changeover.py
+++ b/src/open_dive/scripts/changeover.py
@@ -1,6 +1,0 @@
-import nibabel as nib
-import matplotlib.pyplot as plt
-import numpy as np
-from nilearn import plotting
-import seaborn as sns
-

--- a/src/open_dive/scripts/nifti2png.py
+++ b/src/open_dive/scripts/nifti2png.py
@@ -54,12 +54,22 @@ def main():
         nargs="+",  # Accept one or more arguments
         help="Optional tractogram(s) to plot with slices. Can provide multiple files.",
     )
-    # parser.add_argument(
-    #     "--tractography_values",
-    #     type=float,
-    #     nargs="+",
-    #     help="Values to use for coloring each tractogram (must match number of tractography files)",
-    # )
+    parser.add_argument(
+        "--tractography_values",
+        type=float,
+        nargs="+",
+        help="Values to use for coloring each tractogram (must match number of tractography files)",
+    )
+    parser.add_argument(
+        "--tractography_cmap",
+        help="Matplotlib colormap to use for tractography. Default is plasma if tractograph_values is provided, otherwise Set1.",
+    )
+    parser.add_argument(
+        "--tractography_cmap_range",
+        type=float,
+        nargs=2,
+        help="Optional range to use for the colormap. Default is 0 to 1.",
+    )
 
 
     args = parser.parse_args()
@@ -77,5 +87,8 @@ def main():
         interpolation=args.interpolation,
         scalar_colorbar=args.scalar_colorbar,
         tractography=args.tractography,
+        tractography_values=args.tractography_values,
+        tractography_cmap=args.tractography_cmap,
+        tractography_cmap_range=args.tractography_cmap_range,
     )
 


### PR DESCRIPTION
## Description

I have added code to map tractography values and a colormap to multiple tractograms.

## Issue

* Closes #10 

## Changes Made

* Added `--tractography_values` to plot different values
* Added `--tractography_cmap` to control any Matplotlib colormap. Defaults to plasma if `--tractography_values` is provided, otherwise Set1 for a qualitative colormap.
* Added `--tractography_cmap_range` to control the range of the colormap. Defaults to 0 to 1.

## Testing

<img width="484" alt="image" src="https://github.com/user-attachments/assets/bf6f52e5-2f42-44f0-9a1c-43be8507b979" />

Note we probably want to add a colorbar for this at some point.

* [x] I have performed a self-review of my code.
* [x] I have updated documentation and added docstrings as needed.
