### PR TITLE
Rgb orientation+zoom

### DIFF
--- a/src/open_dive/scripts/run.py
+++ b/src/open_dive/scripts/run.py
@@ -92,14 +92,14 @@ def main():
     tractography_group.add_argument(
         "--tractography_opacity",
         type=float,
+        nargs="+",
         default=0.6,
-        help="Value to use for the tractogram opacity in range (0, 1]. Default is 0.6.",
+        help="Value to use for the tractogram opacity in range (0, 1].If a list, each value corresponds to a tractogram in --tractography_path.  Default is 0.6.",
     )
     tractography_group.add_argument(
-        "--tractography_opacities",
-        type=float,
-        nargs="+",
-        help="List of opacities for each tractogram file. Must match the number of files in --tractography_path. Opacities are in range (0,1]."
+        "--use_orientation_rgb",
+        action = "store_true",
+        help="Use RGB coloring based on local streamline orientation.",
     )
     tractography_group.add_argument(
         "--tractography_colorbar",
@@ -188,7 +188,7 @@ def main():
         scalar_colorbar=args.scalar_colorbar,
         tractography_path=args.tractography_path,
         tractography_opacity=args.tractography_opacity,
-        tractography_opacities=args.tractography_opacities,
+        use_orientation_rgb=args.use_orientation_rgb,
         tractography_values=args.tractography_values,
         tractography_cmap=args.tractography_cmap,
         tractography_cmap_range=args.tractography_cmap_range,

--- a/src/open_dive/scripts/run.py
+++ b/src/open_dive/scripts/run.py
@@ -96,6 +96,12 @@ def main():
         help="Value to use for the tractogram opacity in range (0, 1]. Default is 0.6.",
     )
     tractography_group.add_argument(
+        "--tractography_opacities",
+        type=float,
+        nargs="+",
+        help="List of opacities for each tractogram file. Must match the number of files in --tractography_path. Opacities are in range (0,1]."
+    )
+    tractography_group.add_argument(
         "--tractography_colorbar",
         action="store_true",
         help="Whether to show a tractography values colorbar. Default is False.",
@@ -150,8 +156,18 @@ def main():
         default=None,
         help="Elevation angle of the view.",
     )
+    window_group.add_argument(
+        "--zoom",
+        type=float,
+        default=1.0,
+        help="Zoom factor; Values >1 zoom in, <1 zoom out. Default zoom value is 1.0. Must be positive."
+    )
 
     args = parser.parse_args()
+
+    # If negative or 0 zoom provided, give feedback
+    if args.zoom<=0:
+        parser.error("--zoom must be a positive number. Values > 1 zoom in, values < 1 zoom out.")
 
     # If provided nothing, give help and exit
     if len(sys.argv) == 1:
@@ -172,6 +188,7 @@ def main():
         scalar_colorbar=args.scalar_colorbar,
         tractography_path=args.tractography_path,
         tractography_opacity=args.tractography_opacity,
+        tractography_opacities=args.tractography_opacities,
         tractography_values=args.tractography_values,
         tractography_cmap=args.tractography_cmap,
         tractography_cmap_range=args.tractography_cmap_range,
@@ -182,5 +199,6 @@ def main():
         scale=args.scale,
         azimuth=args.azimuth,
         elevation=args.elevation,
+        zoom=args.zoom,
         glass_brain_path=args.glass_brain,
     )

--- a/src/open_dive/viz.py
+++ b/src/open_dive/viz.py
@@ -101,6 +101,8 @@ def plot_nifti(
         Basis type for the spherical harmonics, either "descoteaux07" or "tournier07"
     scale : float, default 1
         Scale of the tensor glyphs or ODF glyphs
+    zoom : float, default 1
+        Zoom factor for the camera (1.0 = default; <1.0 zooms in; >1.0 zooms out).
     glass_brain_path : os.PathLike, optional
         Optional glass brain mask to overlay
 
@@ -516,7 +518,7 @@ def _set_camera(
     scene_bound_data: np.ndarray | None = None,
     scene_bound_affine: np.ndarray | None = None,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Set the camera position and orientation."""
+    """Set the camera position, orientation, and zoom."""
     if scene_bound_data is not None:
         camera_pos = np.array([0, 0, 1])
         camera_focal = np.array([0, 0, 0])

--- a/src/open_dive/viz.py
+++ b/src/open_dive/viz.py
@@ -220,11 +220,13 @@ def plot_nifti(
         stream_actors= []
         if tractography_opacity is not None:
             # If a single float is provided, expand it to match number of tracts
-            if isinstance(tractography_opacity, float):
-                tractography_opacities = [tractography_opacity] * len(tractography_path)
+            if isinstance(tractography_opacity, float) or (isinstance(tractography_opacity, list) and len(tractography_opacity) == 1):
+                if isinstance(tractography_opacity, list):
+                    tractography_opacities = [tractography_opacity[0]] * len(tractography_path)
+                else:
+                    tractography_opacities =  [tractography_opacity] * len(tractography_path)
             else:
-                tractography_opacities = tractography_opacity
-
+                    tractography_opacities = tractography_opacity
             if len(tractography_opacities) != len(tractography_path):
                 raise ValueError("Length of tractography_opacity list must match number of tractography files.")
             for i, (path, opacity) in enumerate(zip(tractography_path, tractography_opacities)):


### PR DESCRIPTION
## Description

Created Support for Local orientation based RGB coloring and Pre Rendering Zoom. 


## Changes Made


*Added --use_orientation_rgb to color streamlines based on local orientation
*Changed coloring logic to accommodate use_orientation_rgb when no colormap nor tractography values were provided
*Computes local fiber orientation vectors for each streamline segment to generate per-point RGB colors
*Converts orientation vectors (range -1 to 1) to RGB colors (scaled to 0–1) for accurate directional visualization
*Applies the computed RGB colors per point along each streamline
*Added --zoom CLI option to control camera zoom level in scene.
*Modified _set_camera() to use zoom-adjusted camera positioning.
*Updated default camera positioning from fixed 1.5 * max_dim scaling to adjustable scaling by 1.5 * max_dim / zoom to allow zooming in/out.

## Testing

Zoom:

1. Zoom value of 2

COMMAND:

open-dive -n /nfs2/harmonization/BIDS/HCP/sub-100206/dwi/sub-100206_dwi.nii.gz --size 800 600 --value_range 0 1500 --scalar_colorbar --volume_idx 1 --tractography_path /nfs2/harmonization/BIDS/HCP/derivatives/sub-100206/tractseg/TOM_trackings/AF_left.tck /nfs2/harmonization/BIDS/HCP/derivatives/sub-100206/tractseg/TOM_trackings/CST_left.tck --tractography_opacity 0.1 0.9 --tractography_cmap viridis --zoom 2.0

Result:Desired output with prerendered zoom with factor 2

2. Zoom value of 0.5

COMMAND:

open-dive -n /nfs2/harmonization/BIDS/HCP/sub-100206/dwi/sub-100206_dwi.nii.gz --size 800 600 --value_range 0 1500 --scalar_colorbar --volume_idx 1 --tractography_path /nfs2/harmonization/BIDS/HCP/derivatives/sub-100206/tractseg/TOM_trackings/AF_left.tck /nfs2/harmonization/BIDS/HCP/derivatives/sub-100206/tractseg/TOM_trackings/CST_left.tck --tractography_opacity 0.1 0.9 --tractography_cmap viridis --zoom 0.5

Result:Desired output with prerendered zoom with factor of 0.5 



RGB:
1: RGB coloring when no values or colormap provided (default RGB mode)

COMMAND:

open-dive -n /nfs2/harmonization/BIDS/HCP/sub-100206/dwi/sub-100206_dwi.nii.gz \
--volume_idx 0 \
--tractography_path /nfs2/harmonization/BIDS/HCP/derivatives/sub-100206/tractseg/TOM_trackings/AF_left.tck

Result:Desired output with appropriate orientation based coloring


2.Colormap overrides orientation RGB (i.e., no RGB coloring)**

COMMAND:

open-dive -n /nfs2/harmonization/BIDS/HCP/sub-100206/dwi/sub-100206_dwi.nii.gz \
--volume_idx 0 \
--tractography_path /nfs2/harmonization/BIDS/HCP/derivatives/sub-100206/tractseg/TOM_trackings/AF_left.tck \
--tractography_cmap plasma

Result:Desired output with colormap overiding use of orientation based rgb coloring


3.RGB orientation coloring for multiple tracts

COMMAND:

open-dive -n /nfs2/harmonization/BIDS/HCP/sub-100206/dwi/sub-100206_dwi.nii.gz \
--volume_idx 0 \
--tractography_path \
/nfs2/harmonization/BIDS/HCP/derivatives/sub-100206/tractseg/TOM_trackings/AF_left.tck \
/nfs2/harmonization/BIDS/HCP/derivatives/sub-100206/tractseg/TOM_trackings/AF_right.tck

Result:Desired output with local orientation based RGB coloring for both tracts


4.Scalar values + colormap

COMMAND:

open-dive -n /nfs2/harmonization/BIDS/HCP/sub-100206/dwi/sub-100206_dwi.nii.gz \
--volume_idx 0 \
--tractography_path \
/nfs2/harmonization/BIDS/HCP/derivatives/sub-100206/tractseg/TOM_trackings/AF_left.tck \
/nfs2/harmonization/BIDS/HCP/derivatives/sub-100206/tractseg/TOM_trackings/AF_right.tck \
--tractography_values 0.2 0.9 \
--tractography_cmap plasma \
--tractography_colorbar

Result:Desired output with scalar values and colormap


5.Multiple tracts with default opacity and no values (should assign default colors)

COMMAND:

open-dive -n /nfs2/harmonization/BIDS/HCP/sub-100206/dwi/sub-100206_dwi.nii.gz \
--volume_idx 0 \
--tractography_path \
/nfs2/harmonization/BIDS/HCP/derivatives/sub-100206/tractseg/TOM_trackings/AF_left.tck \
/nfs2/harmonization/BIDS/HCP/derivatives/sub-100206/tractseg/TOM_trackings/AF_right.tck

Result:Desired output with multiple tracts appropriately colored based on local orientation

* [ Check] I have performed a self-review of my code.
* [ Check] I have updated documentation and added docstrings as needed.
